### PR TITLE
Fix the python error for web container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,6 @@ web:
   ports:
     - "5000:5000"
   volumes:
-    - .:/opt
+    - .:/code
   links:
     - es


### PR DESCRIPTION
ERROR: for web  Container command 'python' not found or does not exist.

Haven't looked into details, but on difference between original and this version of the docker-compose.yml file is the fix added here.

Verified toggling between the two results in working/not-working, but haven't delved deeper into why.
